### PR TITLE
Version 2.4.0

### DIFF
--- a/.appcast.xml
+++ b/.appcast.xml
@@ -61,5 +61,8 @@
         <item>
             <enclosure url="https://github.com/crowdin/sketch-crowdin/releases/download/2.3.7/sketch-crowdin.sketchplugin.zip" sparkle:version="2.3.7"/>
         </item>
+        <item>
+            <enclosure url="https://github.com/crowdin/sketch-crowdin/releases/download/2.4.0/sketch-crowdin.sketchplugin.zip" sparkle:version="2.4.0"/>
+        </item>
     </channel>
 </rss>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the Crowdin Sketch Plugin extension will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.0]
+
+### Added
+
+- Option to preview strings translations in the current page ([#81](https://github.com/crowdin/sketch-crowdin/pull/81))
+- Option to update texts linked to strings changed in Crowdin ([#81](https://github.com/crowdin/sketch-crowdin/pull/81))
+- Option to preview string keys ([#81](https://github.com/crowdin/sketch-crowdin/pull/81))
+- Recursive search for selected text elements for strings mass adding ([#83](https://github.com/crowdin/sketch-crowdin/pull/83))
+
+### Updated
+
+- Dependencies update ([#78](https://github.com/crowdin/sketch-crowdin/pull/78)), ([#82](https://github.com/crowdin/sketch-crowdin/pull/82))
+
+### Fixed
+
+- Fix: fixed issue with use single string in multiple places ([#80](https://github.com/crowdin/sketch-crowdin/pull/80))
+- Fix: updating text in design if source string was edited ([#79](https://github.com/crowdin/sketch-crowdin/pull/79))
+
 ## [2.3.7]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-crowdin",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Crowdin plugin for Sketch",
   "description": "Localize the UI before programming starts. Translate and preview any design with ease",
   "publisher": "Crowdin",
-  "version": "2.3.7",
+  "version": "2.4.0",
   "engines": {
     "sketch": ">=3.0"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const KEY_NAMING_PATTERN = `${KEY_PREFIX}-key-naming`;
 export const SYMBOL_TYPE = 'symbol-override';
 export const TEXT_TYPE = 'text';
 
-export const PLUGIN_VERSION = '2.3.7';
+export const PLUGIN_VERSION = '2.4.0';
 
 export const STRINGS_KEY_NAMING_OPTIONS = [
     { id: 1, name: 'Artboard.Group.Element_name', },


### PR DESCRIPTION
### Added

- Option to preview strings translations on the current page (#81)
- Option to update texts linked to strings changed in Crowdin (#81)
- Option to preview string keys (#81)
- Recursive search for selected text elements for strings mass adding (#83)

### Updated

- Dependencies update (#78), (#82)

### Fixed

- Fix: fixed issue with use a single string in multiple places (#80)
- Fix: updating text in design if source string was edited (#79)
