### PR TITLE
Version 2.4.1

### DIFF
--- a/.appcast.xml
+++ b/.appcast.xml
@@ -64,5 +64,8 @@
         <item>
             <enclosure url="https://github.com/crowdin/sketch-crowdin/releases/download/2.4.0/sketch-crowdin.sketchplugin.zip" sparkle:version="2.4.0"/>
         </item>
+        <item>
+            <enclosure url="https://github.com/crowdin/sketch-crowdin/releases/download/2.4.1/sketch-crowdin.sketchplugin.zip" sparkle:version="2.4.1"/>
+        </item>
     </channel>
 </rss>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Crowdin Sketch Plugin extension will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1]
+
+### Added
+
+- Added button to remove string from mass adding form ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
+- Added checkbox to push or not hidden strings in mass add string form ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
+- Preview/translate/upload for multiple selected artboards ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
+
+### Updated
+
+- Made string mode tab opened by default ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
+- Preview specific artboards now only in new page ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
+- Disable buttons when nothing is selected ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
+
 ## [2.4.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-crowdin",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Crowdin plugin for Sketch",
   "description": "Localize the UI before programming starts. Translate and preview any design with ease",
   "publisher": "Crowdin",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "engines": {
     "sketch": ">=3.0"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const KEY_NAMING_PATTERN = `${KEY_PREFIX}-key-naming`;
 export const SYMBOL_TYPE = 'symbol-override';
 export const TEXT_TYPE = 'text';
 
-export const PLUGIN_VERSION = '2.4.0';
+export const PLUGIN_VERSION = '2.4.1';
 
 export const STRINGS_KEY_NAMING_OPTIONS = [
     { id: 1, name: 'Artboard.Group.Element_name', },


### PR DESCRIPTION
### Added

- Added button to remove string from mass adding form ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
- Added checkbox to push or not hidden strings in mass add string form ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
- Preview/translate/upload for multiple selected artboards ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))

### Updated

- Made string mode tab opened by default ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
- Preview specific artboards now only in new page ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
- Disable buttons when nothing is selected ([#85](https://github.com/crowdin/sketch-crowdin/pull/85))
