### PR TITLE
Version 2.6.1

### DIFF
--- a/.appcast.xml
+++ b/.appcast.xml
@@ -73,5 +73,8 @@
         <item>
             <enclosure url="https://github.com/crowdin/sketch-crowdin/releases/download/2.6.0/sketch-crowdin.sketchplugin.zip" sparkle:version="2.6.0"/>
         </item>
+        <item>
+            <enclosure url="https://github.com/crowdin/sketch-crowdin/releases/download/2.6.1/sketch-crowdin.sketchplugin.zip" sparkle:version="2.6.1"/>
+        </item>
     </channel>
 </rss>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the Crowdin Sketch Plugin extension will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.1]
+
+### Added
+
+- Link duplicate texts functionality ([#96](https://github.com/crowdin/sketch-crowdin/pull/96))
+
+### Updated
+
+- Added branch id to the pseudo translations request ([#95](https://github.com/crowdin/sketch-crowdin/pull/95))
+- Dependencies update ([#97](https://github.com/crowdin/sketch-crowdin/pull/97))
+
 ## [2.6.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sketch-crowdin",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Crowdin plugin for Sketch",
   "description": "Localize the UI before programming starts. Translate and preview any design with ease",
   "publisher": "Crowdin",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "engines": {
     "sketch": ">=3.0"
   },

--- a/src/constants.js
+++ b/src/constants.js
@@ -11,7 +11,7 @@ export const KEY_NAMING_PATTERN = `${KEY_PREFIX}-key-naming`;
 export const SYMBOL_TYPE = 'symbol-override';
 export const TEXT_TYPE = 'text';
 
-export const PLUGIN_VERSION = '2.6.0';
+export const PLUGIN_VERSION = '2.6.1';
 
 export const STRINGS_KEY_NAMING_OPTIONS = [
     { id: 1, name: 'Artboard.Group.Element_name', },


### PR DESCRIPTION
### Added

- Link duplicate texts functionality ([#96](https://github.com/crowdin/sketch-crowdin/pull/96))

### Updated

- Added branch id to the pseudo translations request ([#95](https://github.com/crowdin/sketch-crowdin/pull/95))
- Dependencies update ([#97](https://github.com/crowdin/sketch-crowdin/pull/97))
